### PR TITLE
Removed hardcoded info. Fixes #131

### DIFF
--- a/src/plugins/CaffeClassifier/resources/classify.py
+++ b/src/plugins/CaffeClassifier/resources/classify.py
@@ -1,12 +1,9 @@
 import sys
-# TODO: Change the next line
-sys.path.append("/home/irishninja/projects/caffe/python");
-
+import os
 import caffe
 
 import numpy as np
 import matplotlib.pyplot as plt
-import os
 
 # Get the values from cmd
 if len(sys.argv) < 3:


### PR DESCRIPTION
However, this means that the executors now need to be started with:
`PYTHONPATH=$PYTHONPATH node node_worker.js`